### PR TITLE
[Logic追加] GitHubAPI扱うリポジトリとモデルの実装

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
   "cSpell.ignorePaths": [
     "l10n**.dart",
-    "generated/"
+    "generated/",
+    "**json.dart"
   ],
   "cSpell.enabledLanguageIds": [
     "markdown",

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -20,3 +20,4 @@ analyzer:
     todo: ignore
     directives_ordering: ignore
     sort_pub_dependencies: ignore
+    lines_longer_than_80_chars: ignore

--- a/lib/domain/model/result.dart
+++ b/lib/domain/model/result.dart
@@ -1,0 +1,9 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+ 
+part '../../generated/domain/model/result.freezed.dart';
+ 
+@freezed
+class Result<T> with _$Result<T> {
+  const factory Result.success(T value) = Success<T>;
+  const factory Result.failure(Exception error) = Failure<T>;
+}

--- a/lib/domain/model/result.dart
+++ b/lib/domain/model/result.dart
@@ -5,5 +5,5 @@ part '../../generated/domain/model/result.freezed.dart';
 @freezed
 class Result<T> with _$Result<T> {
   const factory Result.success(T value) = Success<T>;
-  const factory Result.failure(Exception error) = Failure<T>;
+  const factory Result.failure(Object error) = Failure<T>;
 }

--- a/lib/domain/repository/github/github_api_repository.dart
+++ b/lib/domain/repository/github/github_api_repository.dart
@@ -1,0 +1,9 @@
+import 'package:yumemi_code_check/domain/model/github/search_repository_response.dart';
+import 'package:yumemi_code_check/domain/model/result.dart';
+
+// ignore: one_member_abstracts
+abstract class GithubApiRepository {
+  Future<Result<SearchRepositoryResponse>> searchRepository(
+    String searchKeyword,
+  );
+}

--- a/lib/domain/repository/github/github_api_repository_impl.dart
+++ b/lib/domain/repository/github/github_api_repository_impl.dart
@@ -1,0 +1,33 @@
+import 'package:dio/dio.dart';
+import 'package:yumemi_code_check/domain/model/result.dart';
+import 'package:yumemi_code_check/domain/model/github/search_repository_response.dart';
+import 'package:yumemi_code_check/domain/repository/github/github_api_repository.dart';
+import 'package:quiver/strings.dart';
+import 'package:yumemi_code_check/domain/server/client/github_api_client.dart';
+
+class GithubApiRepositoryImpl implements GithubApiRepository {
+  GithubApiRepositoryImpl([GithubApiClient? client])
+      : _client = client ?? GithubApiClient(Dio());
+
+  final GithubApiClient _client;
+
+  @override
+  Future<Result<SearchRepositoryResponse>> searchRepository(
+    String searchKeyword,
+  ) {
+    if (isBlank(searchKeyword)) {
+      throw ArgumentError.value(
+        searchKeyword,
+        'searchKeyword',
+        'Parameter "searchKeyword" should be not Blank',
+      );
+    }
+
+    return _client
+        .searchRepositories(searchKeyword)
+        .then(Result.success)
+        .catchError((Object error) {
+      return Result<SearchRepositoryResponse>.failure(error);
+    });
+  }
+}

--- a/lib/domain/server/mock/mock_github_api_server.dart
+++ b/lib/domain/server/mock/mock_github_api_server.dart
@@ -1,7 +1,4 @@
-import 'dart:developer';
-
 import 'package:dio/dio.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:yumemi_code_check/domain/server/client/github_api_path.dart';
 

--- a/lib/generated/domain/model/result.freezed.dart
+++ b/lib/generated/domain/model/result.freezed.dart
@@ -1,0 +1,338 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of '../../../domain/model/result.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+mixin _$Result<T> {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T value) success,
+    required TResult Function(Exception error) failure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(T value)? success,
+    TResult Function(Exception error)? failure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T value)? success,
+    TResult Function(Exception error)? failure,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Success<T> value) success,
+    required TResult Function(Failure<T> value) failure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(Success<T> value)? success,
+    TResult Function(Failure<T> value)? failure,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Success<T> value)? success,
+    TResult Function(Failure<T> value)? failure,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ResultCopyWith<T, $Res> {
+  factory $ResultCopyWith(Result<T> value, $Res Function(Result<T>) then) =
+      _$ResultCopyWithImpl<T, $Res>;
+}
+
+/// @nodoc
+class _$ResultCopyWithImpl<T, $Res> implements $ResultCopyWith<T, $Res> {
+  _$ResultCopyWithImpl(this._value, this._then);
+
+  final Result<T> _value;
+  // ignore: unused_field
+  final $Res Function(Result<T>) _then;
+}
+
+/// @nodoc
+abstract class _$$SuccessCopyWith<T, $Res> {
+  factory _$$SuccessCopyWith(
+          _$Success<T> value, $Res Function(_$Success<T>) then) =
+      __$$SuccessCopyWithImpl<T, $Res>;
+  $Res call({T value});
+}
+
+/// @nodoc
+class __$$SuccessCopyWithImpl<T, $Res> extends _$ResultCopyWithImpl<T, $Res>
+    implements _$$SuccessCopyWith<T, $Res> {
+  __$$SuccessCopyWithImpl(
+      _$Success<T> _value, $Res Function(_$Success<T>) _then)
+      : super(_value, (v) => _then(v as _$Success<T>));
+
+  @override
+  _$Success<T> get _value => super._value as _$Success<T>;
+
+  @override
+  $Res call({
+    Object? value = freezed,
+  }) {
+    return _then(_$Success<T>(
+      value == freezed
+          ? _value.value
+          : value // ignore: cast_nullable_to_non_nullable
+              as T,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$Success<T> implements Success<T> {
+  const _$Success(this.value);
+
+  @override
+  final T value;
+
+  @override
+  String toString() {
+    return 'Result<$T>.success(value: $value)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$Success<T> &&
+            const DeepCollectionEquality().equals(other.value, value));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(value));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$SuccessCopyWith<T, _$Success<T>> get copyWith =>
+      __$$SuccessCopyWithImpl<T, _$Success<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T value) success,
+    required TResult Function(Exception error) failure,
+  }) {
+    return success(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(T value)? success,
+    TResult Function(Exception error)? failure,
+  }) {
+    return success?.call(value);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T value)? success,
+    TResult Function(Exception error)? failure,
+    required TResult orElse(),
+  }) {
+    if (success != null) {
+      return success(value);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Success<T> value) success,
+    required TResult Function(Failure<T> value) failure,
+  }) {
+    return success(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(Success<T> value)? success,
+    TResult Function(Failure<T> value)? failure,
+  }) {
+    return success?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Success<T> value)? success,
+    TResult Function(Failure<T> value)? failure,
+    required TResult orElse(),
+  }) {
+    if (success != null) {
+      return success(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Success<T> implements Result<T> {
+  const factory Success(final T value) = _$Success<T>;
+
+  T get value => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  _$$SuccessCopyWith<T, _$Success<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$FailureCopyWith<T, $Res> {
+  factory _$$FailureCopyWith(
+          _$Failure<T> value, $Res Function(_$Failure<T>) then) =
+      __$$FailureCopyWithImpl<T, $Res>;
+  $Res call({Exception error});
+}
+
+/// @nodoc
+class __$$FailureCopyWithImpl<T, $Res> extends _$ResultCopyWithImpl<T, $Res>
+    implements _$$FailureCopyWith<T, $Res> {
+  __$$FailureCopyWithImpl(
+      _$Failure<T> _value, $Res Function(_$Failure<T>) _then)
+      : super(_value, (v) => _then(v as _$Failure<T>));
+
+  @override
+  _$Failure<T> get _value => super._value as _$Failure<T>;
+
+  @override
+  $Res call({
+    Object? error = freezed,
+  }) {
+    return _then(_$Failure<T>(
+      error == freezed
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as Exception,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$Failure<T> implements Failure<T> {
+  const _$Failure(this.error);
+
+  @override
+  final Exception error;
+
+  @override
+  String toString() {
+    return 'Result<$T>.failure(error: $error)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$Failure<T> &&
+            const DeepCollectionEquality().equals(other.error, error));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(error));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$FailureCopyWith<T, _$Failure<T>> get copyWith =>
+      __$$FailureCopyWithImpl<T, _$Failure<T>>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(T value) success,
+    required TResult Function(Exception error) failure,
+  }) {
+    return failure(error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(T value)? success,
+    TResult Function(Exception error)? failure,
+  }) {
+    return failure?.call(error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(T value)? success,
+    TResult Function(Exception error)? failure,
+    required TResult orElse(),
+  }) {
+    if (failure != null) {
+      return failure(error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Success<T> value) success,
+    required TResult Function(Failure<T> value) failure,
+  }) {
+    return failure(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(Success<T> value)? success,
+    TResult Function(Failure<T> value)? failure,
+  }) {
+    return failure?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Success<T> value)? success,
+    TResult Function(Failure<T> value)? failure,
+    required TResult orElse(),
+  }) {
+    if (failure != null) {
+      return failure(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class Failure<T> implements Result<T> {
+  const factory Failure(final Exception error) = _$Failure<T>;
+
+  Exception get error => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  _$$FailureCopyWith<T, _$Failure<T>> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/generated/domain/model/result.freezed.dart
+++ b/lib/generated/domain/model/result.freezed.dart
@@ -19,19 +19,19 @@ mixin _$Result<T> {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(T value) success,
-    required TResult Function(Exception error) failure,
+    required TResult Function(Object error) failure,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult Function(T value)? success,
-    TResult Function(Exception error)? failure,
+    TResult Function(Object error)? failure,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(T value)? success,
-    TResult Function(Exception error)? failure,
+    TResult Function(Object error)? failure,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -136,7 +136,7 @@ class _$Success<T> implements Success<T> {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(T value) success,
-    required TResult Function(Exception error) failure,
+    required TResult Function(Object error) failure,
   }) {
     return success(value);
   }
@@ -145,7 +145,7 @@ class _$Success<T> implements Success<T> {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult Function(T value)? success,
-    TResult Function(Exception error)? failure,
+    TResult Function(Object error)? failure,
   }) {
     return success?.call(value);
   }
@@ -154,7 +154,7 @@ class _$Success<T> implements Success<T> {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(T value)? success,
-    TResult Function(Exception error)? failure,
+    TResult Function(Object error)? failure,
     required TResult orElse(),
   }) {
     if (success != null) {
@@ -209,7 +209,7 @@ abstract class _$$FailureCopyWith<T, $Res> {
   factory _$$FailureCopyWith(
           _$Failure<T> value, $Res Function(_$Failure<T>) then) =
       __$$FailureCopyWithImpl<T, $Res>;
-  $Res call({Exception error});
+  $Res call({Object error});
 }
 
 /// @nodoc
@@ -230,7 +230,7 @@ class __$$FailureCopyWithImpl<T, $Res> extends _$ResultCopyWithImpl<T, $Res>
       error == freezed
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
-              as Exception,
+              as Object,
     ));
   }
 }
@@ -241,7 +241,7 @@ class _$Failure<T> implements Failure<T> {
   const _$Failure(this.error);
 
   @override
-  final Exception error;
+  final Object error;
 
   @override
   String toString() {
@@ -269,7 +269,7 @@ class _$Failure<T> implements Failure<T> {
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(T value) success,
-    required TResult Function(Exception error) failure,
+    required TResult Function(Object error) failure,
   }) {
     return failure(error);
   }
@@ -278,7 +278,7 @@ class _$Failure<T> implements Failure<T> {
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
     TResult Function(T value)? success,
-    TResult Function(Exception error)? failure,
+    TResult Function(Object error)? failure,
   }) {
     return failure?.call(error);
   }
@@ -287,7 +287,7 @@ class _$Failure<T> implements Failure<T> {
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
     TResult Function(T value)? success,
-    TResult Function(Exception error)? failure,
+    TResult Function(Object error)? failure,
     required TResult orElse(),
   }) {
     if (failure != null) {
@@ -329,9 +329,9 @@ class _$Failure<T> implements Failure<T> {
 }
 
 abstract class Failure<T> implements Result<T> {
-  const factory Failure(final Exception error) = _$Failure<T>;
+  const factory Failure(final Object error) = _$Failure<T>;
 
-  Exception get error => throw _privateConstructorUsedError;
+  Object get error => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   _$$FailureCopyWith<T, _$Failure<T>> get copyWith =>
       throw _privateConstructorUsedError;

--- a/test/domain/repository/github_api_repository_test.dart
+++ b/test/domain/repository/github_api_repository_test.dart
@@ -1,14 +1,8 @@
-import 'dart:async';
 import 'dart:convert';
-import 'dart:developer';
-import 'dart:ffi';
-import 'dart:io';
 
 import 'package:dio/dio.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:yumemi_code_check/domain/model/github/search_repository_response.dart';
-import 'package:yumemi_code_check/domain/model/result.dart';
 import 'package:yumemi_code_check/domain/repository/github/github_api_repository.dart';
 import 'package:yumemi_code_check/domain/repository/github/github_api_repository_impl.dart';
 import 'package:yumemi_code_check/domain/server/client/github_api_client.dart';
@@ -16,7 +10,7 @@ import 'package:yumemi_code_check/domain/server/client/github_api_path.dart';
 import 'package:yumemi_code_check/domain/server/mock/mock_github_api_server.dart';
 import 'package:yumemi_code_check/domain/server/mock/search_repository_json.dart';
 
-void main() async {
+void main() {
   late GithubApiClient githubApiClient;
   late MockGithubApiServer mockServer;
   late GithubApiRepository repository;

--- a/test/domain/repository/github_api_repository_test.dart
+++ b/test/domain/repository/github_api_repository_test.dart
@@ -1,0 +1,85 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:developer';
+import 'dart:ffi';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yumemi_code_check/domain/model/github/search_repository_response.dart';
+import 'package:yumemi_code_check/domain/model/result.dart';
+import 'package:yumemi_code_check/domain/repository/github/github_api_repository.dart';
+import 'package:yumemi_code_check/domain/repository/github/github_api_repository_impl.dart';
+import 'package:yumemi_code_check/domain/server/client/github_api_client.dart';
+import 'package:yumemi_code_check/domain/server/client/github_api_path.dart';
+import 'package:yumemi_code_check/domain/server/mock/mock_github_api_server.dart';
+import 'package:yumemi_code_check/domain/server/mock/search_repository_json.dart';
+
+void main() async {
+  late GithubApiClient githubApiClient;
+  late MockGithubApiServer mockServer;
+  late GithubApiRepository repository;
+  final json = jsonDecode(searchRepositoryJson) as Map<String, dynamic>;
+  final responseFromJson = SearchRepositoryResponse.fromJson(json);
+
+  setUp(() {
+    mockServer = MockGithubApiServer();
+    githubApiClient = GithubApiClient(mockServer.dio);
+    repository = GithubApiRepositoryImpl(githubApiClient);
+  });
+
+  group('Github Api Repository', () {
+    group('searchRepository()', () {
+      test('無効引数', () {
+        expect(
+          () => repository.searchRepository(''),
+          throwsArgumentError,
+        );
+        expect(
+          () => repository.searchRepository('  '),
+          throwsArgumentError,
+        );
+        expect(
+          () => repository.searchRepository('　　'),
+          throwsArgumentError,
+        );
+      });
+
+      test('Mockサーバー成功レスポンス', () async {
+        await mockServer.onGetSuccessStatuses(
+          path: githubSearchRepositoriesUrl,
+          responseMap: mockSearchStatusResponse,
+          statusFunction: {
+            200: Future(() async {
+              expect(
+                await githubApiClient.searchRepositories('kotlin'),
+                responseFromJson,
+              );
+            })
+          },
+        );
+      });
+      test('Mockサーバー失敗レスポンス', () async {
+        await mockServer.onGetFailureStatus(
+          path: githubSearchRepositoriesUrl,
+          responseMap: mockSearchStatusResponse,
+          statusFunction: {
+            503: Future(() async {
+              final response = await repository.searchRepository('kotlin');
+              response.when(
+                success: (res) => throw Exception('response should be failure'),
+                failure: (error) {
+                  if (error is! DioError) {
+                    throw Exception('$error response should be DioError');
+                  }
+                  expect(error.response?.statusCode, 503);
+                },
+              );
+            })
+          },
+        );
+      });
+    });
+  });
+}

--- a/test/domain/server/client/github_api_client_test.dart
+++ b/test/domain/server/client/github_api_client_test.dart
@@ -12,7 +12,7 @@ void main() {
   final json = jsonDecode(searchRepositoryJson) as Map<String, dynamic>;
 
   group('Github Api Client', () {
-    test('モデルのパーステスト', () async {
+    test('モデルのパーステスト', () {
       SearchRepositoryResponse.fromJson(json);
     });
 

--- a/test/domain/server/client/github_api_client_test.dart
+++ b/test/domain/server/client/github_api_client_test.dart
@@ -26,8 +26,10 @@ void main() {
         responseMap: mockSearchStatusResponse,
         statusFunction: {
           200: () {
-            expect(githubApiClient.searchRepositories('aa'),
-                completion(responseFromJson),);
+            expect(
+              githubApiClient.searchRepositories('aa'),
+              completion(responseFromJson),
+            );
           },
         },
       );

--- a/test/domain/server/client/github_api_client_test.dart
+++ b/test/domain/server/client/github_api_client_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:developer';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:yumemi_code_check/domain/model/github/search_repository_response.dart';
@@ -16,21 +17,23 @@ void main() {
       SearchRepositoryResponse.fromJson(json);
     });
 
-    test('MockサーバでのGetテスト', () {
+    test('MockサーバでのGetテスト', () async {
       final mockServer = MockGithubApiServer();
       githubApiClient = GithubApiClient(mockServer.dio);
       final responseFromJson = SearchRepositoryResponse.fromJson(json);
 
-      mockServer.onGetSuccessStatuses(
+      await mockServer.onGetSuccessStatuses(
         path: githubSearchRepositoriesUrl,
         responseMap: mockSearchStatusResponse,
         statusFunction: {
-          200: () {
-            expect(
-              githubApiClient.searchRepositories('aa'),
-              completion(responseFromJson),
-            );
-          },
+          200: Future(
+            () async {
+              expect(
+                await githubApiClient.searchRepositories('aa'),
+                responseFromJson,
+              );
+            },
+          )
         },
       );
     });

--- a/test/domain/server/client/github_api_client_test.dart
+++ b/test/domain/server/client/github_api_client_test.dart
@@ -25,9 +25,9 @@ void main() {
         path: githubSearchRepositoriesUrl,
         responseMap: mockSearchStatusResponse,
         statusFunction: {
-          200: () async {
-            final response = await githubApiClient.searchRepositories('aa');
-            expect(response, responseFromJson);
+          200: () {
+            expect(githubApiClient.searchRepositories('aa'),
+                completion(responseFromJson),);
           },
         },
       );

--- a/test/domain/server/client/github_api_client_test.dart
+++ b/test/domain/server/client/github_api_client_test.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:developer';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:yumemi_code_check/domain/model/github/search_repository_response.dart';


### PR DESCRIPTION
## 概要
<!-- なにをやったかを書く -->
- Resultクラスの作成
- GithubApiRepositoryクラスの作成
- 作成したクラスのテスト

## 修正箇所
<!-- 修正した場所があれば書く -->
- `MockGIthubApiServer`の`onGetSuccessStatus()`と`onGetFailureStatus()'が非同期で動いていなかったので修正をした。
- `forEach`と`void Function()`はそれぞれasync/awaitがうまく動かないらしい。
  - https://qiita.com/masashi_goto/items/ae23187c374e292c7ffb

## issues
<!-- issueのリンクを書く -->
- #7 

## TODO
<!-- issueのTODOをコピーする -->
- [x] リポジトリのインターフェース作成
- [x] リポジトリの実装
- [x] リポジトリのテストケース作成
- [ ] ~リポジトリのMockを作成~
  - mock_http_adapterで十分かなと...（必要に駆られたら作ります）


## 影響範囲
<!-- 変更によるり他へ影響があれば書く -->
テストが通れば無し

## 参考文献など
<!-- 参考文献などあれば書く -->
- テスト関係
  - https://qiita.com/kasa_le/items/bf48b65fdb8cf1fa0421
  - https://api.flutter.dev/flutter/flutter_test/setUp.html
  - https://api.dart.dev/stable/2.16.2/dart-core/ArgumentError/ArgumentError.value.html

## 動作条件
<!-- 動作条件を書く　バージョンなど -->
- Flutter 2.10.5
- Dart 2.16.2
- MinimumOSVersion = 9.0
- compileSdkVersion = 31
- minSdkVersion = 16
- targetSdkVersion = 31
