### PR TITLE
Feature/search-page-ui

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,8 +11,10 @@
     "json"
   ],
   "cSpell.words": [
+    "LTRB",
     "mockito",
     "noto",
+    "riverpod",
     "yumemi"
   ],
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -8,12 +8,26 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final lightTheme = ThemeData.light();
+    final lightDeco = lightTheme.inputDecorationTheme;
+    final lightText = lightTheme.textTheme;
+
+    final darkTheme = ThemeData.dark();
+    final darkDeco = darkTheme.inputDecorationTheme;
+    final darkText = darkTheme.textTheme;
+
     return MaterialApp(
       title: 'SearchRepositoryApp',
-      theme: ThemeData.light().copyWith(
-        textTheme: GoogleFonts.notoSansTextTheme(),
+      theme: lightTheme.copyWith(
+        textTheme: GoogleFonts.notoSansTextTheme(lightText),
+        inputDecorationTheme:
+            lightDeco.copyWith(fillColor: Colors.grey.shade200),
       ),
-      darkTheme: ThemeData.dark(),
+      darkTheme: darkTheme.copyWith(
+        textTheme: GoogleFonts.notoSansTextTheme(darkText),
+        inputDecorationTheme:
+            darkDeco.copyWith(fillColor: Colors.grey.shade700),
+      ),
       home: const SearchPage(),
       localizationsDelegates: L10n.localizationsDelegates,
       supportedLocales: L10n.supportedLocales,

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:yumemi_code_check/l10n/l10n.dart';
 import 'package:yumemi_code_check/ui/page/search_page.dart';
 
 class App extends StatelessWidget {
@@ -14,6 +15,8 @@ class App extends StatelessWidget {
       ),
       darkTheme: ThemeData.dark(),
       home: const SearchPage(),
+      localizationsDelegates: L10n.localizationsDelegates,
+      supportedLocales: L10n.supportedLocales,
     );
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,3 +1,10 @@
 {
-  "@@locale": "en"
+  "@@locale": "en",
+  "title": "GitHub Repository Search",
+  "blankMessage": "Input required",
+  "limitExceed": "Input limit reached",
+  "inputKeyword": "Input keyword",
+  "serverError": "The server error has occurred.",
+  "networkError": "The Internet error has occurred.",
+  "unknownError": "Unknown error has occurred."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6,5 +6,6 @@
   "inputKeyword": "Input keyword",
   "serverError": "The server error has occurred.",
   "networkError": "The Internet error has occurred.",
-  "unknownError": "Unknown error has occurred."
+  "unknownError": "Unknown error has occurred.",
+  "search": "Search"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,0 +1,10 @@
+{
+  "@@locale":"ja",
+  "title":"GitHubリポジトリ検索",
+  "blankMessage": "入力が必要です",
+  "limitExceed":"入力上限に達しました",
+  "inputKeyword":"キーワード入力",
+  "serverError":"サーバーエラーが発生しています",
+  "networkError":"インターネットエラーが発生しています",
+  "unknownError":"不明なエラーが発生しています"
+}

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,10 +1,11 @@
 {
-  "@@locale":"ja",
-  "title":"GitHubリポジトリ検索",
+  "@@locale": "ja",
+  "title": "GitHubリポジトリ検索",
   "blankMessage": "入力が必要です",
-  "limitExceed":"入力上限に達しました",
-  "inputKeyword":"キーワード入力",
-  "serverError":"サーバーエラーが発生しています",
-  "networkError":"インターネットエラーが発生しています",
-  "unknownError":"不明なエラーが発生しています"
+  "limitExceed": "入力上限に達しました",
+  "inputKeyword": "キーワード入力",
+  "serverError": "サーバーエラーが発生しています",
+  "networkError": "インターネットエラーが発生しています",
+  "unknownError": "不明なエラーが発生しています",
+  "search": "検索"
 }

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -135,6 +135,12 @@ abstract class L10n {
   /// In en, this message translates to:
   /// **'Unknown error has occurred.'**
   String get unknownError;
+
+  /// No description provided for @search.
+  ///
+  /// In en, this message translates to:
+  /// **'Search'**
+  String get search;
 }
 
 class _L10nDelegate extends LocalizationsDelegate<L10n> {

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -7,6 +7,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:intl/intl.dart' as intl;
 
 import 'l10n_en.dart';
+import 'l10n_ja.dart';
 
 /// Callers can lookup localized strings with an instance of L10n returned
 /// by `L10n.of(context)`.
@@ -89,9 +90,51 @@ abstract class L10n {
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
-    Locale('en')
+    Locale('en'),
+    Locale('ja')
   ];
 
+  /// No description provided for @title.
+  ///
+  /// In en, this message translates to:
+  /// **'GitHub Repository Search'**
+  String get title;
+
+  /// No description provided for @blankMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Input required'**
+  String get blankMessage;
+
+  /// No description provided for @limitExceed.
+  ///
+  /// In en, this message translates to:
+  /// **'Input limit reached'**
+  String get limitExceed;
+
+  /// No description provided for @inputKeyword.
+  ///
+  /// In en, this message translates to:
+  /// **'Input keyword'**
+  String get inputKeyword;
+
+  /// No description provided for @serverError.
+  ///
+  /// In en, this message translates to:
+  /// **'The server error has occurred.'**
+  String get serverError;
+
+  /// No description provided for @networkError.
+  ///
+  /// In en, this message translates to:
+  /// **'The Internet error has occurred.'**
+  String get networkError;
+
+  /// No description provided for @unknownError.
+  ///
+  /// In en, this message translates to:
+  /// **'Unknown error has occurred.'**
+  String get unknownError;
 }
 
 class _L10nDelegate extends LocalizationsDelegate<L10n> {
@@ -103,7 +146,7 @@ class _L10nDelegate extends LocalizationsDelegate<L10n> {
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['en'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>['en', 'ja'].contains(locale.languageCode);
 
   @override
   bool shouldReload(_L10nDelegate old) => false;
@@ -115,6 +158,7 @@ L10n lookupL10n(Locale locale) {
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
     case 'en': return L10nEn();
+    case 'ja': return L10nJa();
   }
 
   throw FlutterError(

--- a/lib/l10n/l10n_en.dart
+++ b/lib/l10n/l10n_en.dart
@@ -7,5 +7,24 @@ import 'l10n.dart';
 class L10nEn extends L10n {
   L10nEn([String locale = 'en']) : super(locale);
 
+  @override
+  String get title => 'GitHub Repository Search';
 
+  @override
+  String get blankMessage => 'Input required';
+
+  @override
+  String get limitExceed => 'Input limit reached';
+
+  @override
+  String get inputKeyword => 'Input keyword';
+
+  @override
+  String get serverError => 'The server error has occurred.';
+
+  @override
+  String get networkError => 'The Internet error has occurred.';
+
+  @override
+  String get unknownError => 'Unknown error has occurred.';
 }

--- a/lib/l10n/l10n_en.dart
+++ b/lib/l10n/l10n_en.dart
@@ -27,4 +27,7 @@ class L10nEn extends L10n {
 
   @override
   String get unknownError => 'Unknown error has occurred.';
+
+  @override
+  String get search => 'Search';
 }

--- a/lib/l10n/l10n_ja.dart
+++ b/lib/l10n/l10n_ja.dart
@@ -1,0 +1,30 @@
+
+
+
+import 'l10n.dart';
+
+/// The translations for Japanese (`ja`).
+class L10nJa extends L10n {
+  L10nJa([String locale = 'ja']) : super(locale);
+
+  @override
+  String get title => 'GitHubリポジトリ検索';
+
+  @override
+  String get blankMessage => '入力が必要です';
+
+  @override
+  String get limitExceed => '入力上限に達しました';
+
+  @override
+  String get inputKeyword => 'キーワード入力';
+
+  @override
+  String get serverError => 'サーバーエラーが発生しています';
+
+  @override
+  String get networkError => 'インターネットエラーが発生しています';
+
+  @override
+  String get unknownError => '不明なエラーが発生しています';
+}

--- a/lib/l10n/l10n_ja.dart
+++ b/lib/l10n/l10n_ja.dart
@@ -27,4 +27,7 @@ class L10nJa extends L10n {
 
   @override
   String get unknownError => '不明なエラーが発生しています';
+
+  @override
+  String get search => '検索';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:yumemi_code_check/app.dart';
 
 void main() {
-  runApp(const App());
+  runApp(const ProviderScope(child: App()));
 }

--- a/lib/ui/page/search_page.dart
+++ b/lib/ui/page/search_page.dart
@@ -1,14 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:quiver/strings.dart';
+import 'package:yumemi_code_check/domain/model/github/search_repository_response.dart';
+import 'package:yumemi_code_check/domain/model/result.dart';
 import 'package:yumemi_code_check/l10n/l10n.dart';
+import 'package:yumemi_code_check/ui/view_model/github_api_repository_provider.dart';
+import 'package:yumemi_code_check/ui/widget/search_failure.dart';
+import 'package:yumemi_code_check/ui/widget/search_success.dart';
 
 class SearchPage extends HookConsumerWidget {
   const SearchPage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final loadingState = useState(false);
+    final resultState = useState<Result<SearchRepositoryResponse>?>(null);
     final formKey = GlobalKey<FormState>();
+
     void onSubmit() {
       if (formKey.currentState!.validate()) {
         formKey.currentState!.save();
@@ -26,7 +35,15 @@ class SearchPage extends HookConsumerWidget {
             child: Form(
               key: formKey,
               child: TextFormField(
-                onSaved: (value) {},
+                onSaved: (value) async {
+                  if (value != null) {
+                    loadingState.value = true;
+                    resultState.value = await ref
+                        .watch(githubApiRepositoryProvider)
+                        .searchRepository(value);
+                    loadingState.value = false;
+                  }
+                },
                 validator: (value) {
                   if (isBlank(value)) {
                     return L10n.of(context)!.blankMessage;
@@ -52,6 +69,19 @@ class SearchPage extends HookConsumerWidget {
               ),
             ),
           ),
+          if (loadingState.value) const CircularProgressIndicator(),
+          Builder(
+            builder: (context) {
+              final result = resultState.value;
+              if (result is Success<SearchRepositoryResponse>) {
+                return SearchSuccess(success: result);
+              }
+              if (result is Failure<SearchRepositoryResponse>) {
+                return SearchFailure(failure: result);
+              }
+              return Container();
+            },
+          )
         ],
       ),
     );

--- a/lib/ui/page/search_page.dart
+++ b/lib/ui/page/search_page.dart
@@ -1,13 +1,59 @@
 import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:quiver/strings.dart';
+import 'package:yumemi_code_check/l10n/l10n.dart';
 
-class SearchPage extends StatelessWidget {
+class SearchPage extends HookConsumerWidget {
   const SearchPage({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final formKey = GlobalKey<FormState>();
+    void onSubmit() {
+      if (formKey.currentState!.validate()) {
+        formKey.currentState!.save();
+      }
+    }
+
     return Scaffold(
-      appBar: AppBar(title: const Text('リポジトリ検索'),),
-      body: const Center(),
+      appBar: AppBar(
+        title: Text(L10n.of(context)!.title),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Form(
+              key: formKey,
+              child: TextFormField(
+                onSaved: (value) {},
+                validator: (value) {
+                  if (isBlank(value)) {
+                    return L10n.of(context)!.blankMessage;
+                  }
+                  if (value!.length > 255) {
+                    return L10n.of(context)!.limitExceed;
+                  }
+                  return null;
+                },
+                onFieldSubmitted: (_) => onSubmit(),
+                keyboardType: TextInputType.text,
+                maxLength: 255,
+                decoration: InputDecoration(
+                  prefixIcon: const Icon(Icons.search_outlined),
+                  labelText: L10n.of(context)!.inputKeyword,
+                  suffixIcon: TextButton(
+                    onPressed: onSubmit,
+                    child: Text(L10n.of(context)!.search),
+                  ),
+                  border: const OutlineInputBorder(),
+                  filled: true,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/ui/view_model/github_api_repository_provider.dart
+++ b/lib/ui/view_model/github_api_repository_provider.dart
@@ -1,0 +1,26 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:yumemi_code_check/domain/repository/github/github_api_repository.dart';
+import 'package:yumemi_code_check/domain/repository/github/github_api_repository_impl.dart';
+import 'package:yumemi_code_check/domain/server/client/github_api_client.dart';
+import 'package:yumemi_code_check/domain/server/mock/mock_github_api_server.dart';
+
+final flavorProvider =
+    Provider.autoDispose((ref) => const String.fromEnvironment('FLAVOR'));
+
+final mockServerProvider = Provider.autoDispose((ref) {
+  final flavor = ref.watch(flavorProvider);
+  if (flavor == 'dev') {
+    return MockGithubApiServer();
+  }
+  return null;
+});
+
+final githubApiRepositoryProvider =
+    Provider.autoDispose<GithubApiRepository>((ref) {
+  final mock = ref.watch(mockServerProvider);
+  if (mock != null) {
+    return GithubApiRepositoryImpl(GithubApiClient(mock.dio));
+  } else {
+    return GithubApiRepositoryImpl();
+  }
+});

--- a/lib/ui/view_model/github_api_repository_provider.dart
+++ b/lib/ui/view_model/github_api_repository_provider.dart
@@ -2,7 +2,9 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:yumemi_code_check/domain/repository/github/github_api_repository.dart';
 import 'package:yumemi_code_check/domain/repository/github/github_api_repository_impl.dart';
 import 'package:yumemi_code_check/domain/server/client/github_api_client.dart';
+import 'package:yumemi_code_check/domain/server/client/github_api_path.dart';
 import 'package:yumemi_code_check/domain/server/mock/mock_github_api_server.dart';
+import 'package:yumemi_code_check/domain/server/mock/search_repository_json.dart';
 
 final flavorProvider =
     Provider.autoDispose((ref) => const String.fromEnvironment('FLAVOR'));
@@ -10,7 +12,13 @@ final flavorProvider =
 final mockServerProvider = Provider.autoDispose((ref) {
   final flavor = ref.watch(flavorProvider);
   if (flavor == 'dev') {
-    return MockGithubApiServer();
+    final mock = MockGithubApiServer()
+      ..setGetSuccessResponse(
+        githubSearchRepositoriesUrl,
+        200,
+        mockSearchStatusResponse[200],
+      );
+    return mock;
   }
   return null;
 });

--- a/lib/ui/widget/search_failure.dart
+++ b/lib/ui/widget/search_failure.dart
@@ -1,0 +1,42 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:yumemi_code_check/domain/model/github/search_repository_response.dart';
+import 'package:yumemi_code_check/domain/model/result.dart';
+import 'package:yumemi_code_check/l10n/l10n.dart';
+
+class SearchFailure extends StatelessWidget {
+  const SearchFailure({Key? key, required this.failure}) : super(key: key);
+  final Failure<SearchRepositoryResponse> failure;
+  @override
+  Widget build(BuildContext context) {
+    var message = L10n.of(context)!.unknownError;
+    final error = failure.error;
+    if (error is DioError) {
+      if (error.response != null) {
+        if (error.response!.statusCode == 503) {
+          message = L10n.of(context)!.serverError;
+        }
+      }
+      if (error is SocketException) {
+        message = L10n.of(context)!.networkError;
+      }
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Row(
+        children: [
+          const Padding(
+            padding: EdgeInsets.all(8),
+            child: Icon(
+              Icons.highlight_off,
+              color: Colors.red,
+            ),
+          ),
+          Text(message)
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/widget/search_success.dart
+++ b/lib/ui/widget/search_success.dart
@@ -10,13 +10,27 @@ class SearchSuccess extends StatelessWidget {
   List<GithubRepositoryInfo> get items => success.value.items;
   @override
   Widget build(BuildContext context) {
-    return ListView.builder(
-      itemBuilder: (context, index) {
-        return ListTile(
-          title: Text(items[index].name),
-        );
-      },
-      itemCount: items.length,
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Column(
+          children: [
+            Text(
+              '${success.value.totalCount}HIT',
+            ),
+            Expanded(
+              child: ListView.builder(
+                itemBuilder: (context, index) {
+                  return ListTile(
+                    subtitle: Text(items[index].name),
+                  );
+                },
+                itemCount: items.length,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/ui/widget/search_success.dart
+++ b/lib/ui/widget/search_success.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:yumemi_code_check/domain/model/github/github_repository_info.dart';
+import 'package:yumemi_code_check/domain/model/github/search_repository_response.dart';
+import 'package:yumemi_code_check/domain/model/result.dart';
+
+class SearchSuccess extends StatelessWidget {
+  const SearchSuccess({Key? key, required this.success}) : super(key: key);
+  final Success<SearchRepositoryResponse> success;
+
+  List<GithubRepositoryInfo> get items => success.value.items;
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemBuilder: (context, index) {
+        return ListTile(
+          title: Text(items[index].name),
+        );
+      },
+      itemCount: items.length,
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,6 +209,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_hooks:
+    dependency: "direct main"
+    description:
+      name: flutter_hooks
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.18.3"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -230,6 +237,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_riverpod:
+    dependency: transitive
+    description:
+      name: flutter_riverpod
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -277,6 +291,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  hooks_riverpod:
+    dependency: "direct main"
+    description:
+      name: hooks_riverpod
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
   http:
     dependency: transitive
     description:
@@ -536,6 +557,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.1"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
   shelf:
     dependency: transitive
     description:
@@ -583,6 +611,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.10.0"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.2+1"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,8 +29,12 @@ dependencies:
   http_mock_adapter: ^0.3.2
   cupertino_icons: ^1.0.2
 
-  #Style
+  # Style
   google_fonts: ^3.0.1
+
+  # Provider
+  hooks_riverpod: ^1.0.3
+  flutter_hooks: ^0.18.3
 
 
 dev_dependencies:
@@ -62,7 +66,6 @@ dev_dependencies:
   flutter_lints: ^1.0.0
 
 flutter:
-
   uses-material-design: true
 
 flutter_icons:


### PR DESCRIPTION
## 概要
<!-- なにをやったかを書く -->
- リポジトリ検索ページUIの実装
- 多言語対応
- riverpodの追加

## UIの比較
<!-- UIの変更があった場合は書く -->
| 変更前 | 変更後 |
| -- | -- |
| 画像　| ![flutter_01](https://user-images.githubusercontent.com/54800851/170170938-cb551f21-6bcb-497e-8d4b-2251ca89ebe0.png)|

## issues
<!-- issueのリンクを書く -->
- #16 

## TODO
<!-- issueのTODOをコピーする -->
- [x] 多言語対応
- [ ] ~SilverScroll~
  - toolBarにTextFieldがかぶってうまく表現できなかったため諦めた
  - flutter_sticky_headerを使ったが、うまく表現できなかった。
- [ ] ~リポジトリ表示のアニメーション~
  - レスポンスの表示時にフェードインさせようと思ったが、うまく表現できなかった。
  - たぶん、loadStateと組み合わせてやる感じだと思った。
- [x] riverpodの追加

## 影響範囲
<!-- 変更によるり他へ影響があれば書く -->
Flavor-devでしか使わないproviderはprdのときどうなるか分からない。

## 参考文献など
<!-- 参考文献などあれば書く -->
- https://material.io/components/app-bars-bottom
- https://itome.team/blog/2019/12/flutter-advent-calendar-day12/
- https://flutter.salon/flutter/l10n/

## 動作条件
<!-- 動作条件を書く　バージョンなど -->
- Flutter 2.10.5
- Dart 2.16.2
- MinimumOSVersion = 9.0
- compileSdkVersion = 31
- minSdkVersion = 16
- targetSdkVersion = 31
