### PR TITLE
fix: インターネット通信を許可

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.yumemi_code_check">
+   <uses-permission android:name="android.permission.INTERNET" /> 
    <application
         android:label="${appNamePrefix}ゆめみCordCheck"
         android:name="${applicationName}"


### PR DESCRIPTION
## 概要
<!-- なにをやったかを書く -->
Androidのインターネット通信を許可

## 修正箇所
<!-- 修正した場所があれば書く -->
- android のmain/Manufest.xml

## issues
<!-- issueのリンクを書く -->
- #20 

## 影響範囲
<!-- 変更によるり他へ影響があれば書く -->
なし

## 参考文献など
<!-- 参考文献などあれば書く -->
- https://qiita.com/Frog_kt/items/130c4105a0e94dc25777

## 動作条件
<!-- 動作条件を書く　バージョンなど -->
- Flutter 2.10.5
- Dart 2.16.2
- MinimumOSVersion = 9.0
- compileSdkVersion = 31
- minSdkVersion = 16
- targetSdkVersion = 31
