### PR TITLE
[Fix] フィードバックのリファクタリング

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,4 +17,6 @@
     "riverpod",
     "yumemi"
   ],
+  "dart.sdkPath": ".fvm/flutter_sdk",
+  "dart.flutterSdkPath": ".fvm/flutter_sdk"
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -28,7 +28,7 @@ class App extends StatelessWidget {
         inputDecorationTheme:
             darkDeco.copyWith(fillColor: Colors.grey.shade700),
       ),
-      home: const SearchPage(),
+      home: SearchPage(),
       localizationsDelegates: L10n.localizationsDelegates,
       supportedLocales: L10n.supportedLocales,
     );

--- a/lib/ui/page/search_page.dart
+++ b/lib/ui/page/search_page.dart
@@ -67,6 +67,7 @@ class SearchPage extends HookConsumerWidget {
                   border: const OutlineInputBorder(),
                   filled: true,
                 ),
+                textInputAction: TextInputAction.search,
               ),
             ),
           ),

--- a/lib/ui/page/search_page.dart
+++ b/lib/ui/page/search_page.dart
@@ -10,13 +10,13 @@ import 'package:yumemi_code_check/ui/widget/search_failure.dart';
 import 'package:yumemi_code_check/ui/widget/search_success.dart';
 
 class SearchPage extends HookConsumerWidget {
-  const SearchPage({Key? key}) : super(key: key);
+  SearchPage({Key? key}) : super(key: key);
+  final formKey = GlobalKey<FormState>();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final loadingState = useState(false);
     final resultState = useState<Result<SearchRepositoryResponse>?>(null);
-    final formKey = GlobalKey<FormState>();
 
     void onSubmit() {
       if (formKey.currentState!.validate()) {

--- a/lib/ui/view_model/github_api_repository_provider.dart
+++ b/lib/ui/view_model/github_api_repository_provider.dart
@@ -7,9 +7,9 @@ import 'package:yumemi_code_check/domain/server/mock/mock_github_api_server.dart
 import 'package:yumemi_code_check/domain/server/mock/search_repository_json.dart';
 
 final flavorProvider =
-    Provider.autoDispose((ref) => const String.fromEnvironment('FLAVOR'));
+    Provider((ref) => const String.fromEnvironment('FLAVOR'));
 
-final mockServerProvider = Provider.autoDispose((ref) {
+final mockServerProvider = Provider((ref) {
   final flavor = ref.watch(flavorProvider);
   if (flavor == 'dev') {
     final mock = MockGithubApiServer()
@@ -23,8 +23,7 @@ final mockServerProvider = Provider.autoDispose((ref) {
   return null;
 });
 
-final githubApiRepositoryProvider =
-    Provider.autoDispose<GithubApiRepository>((ref) {
+final githubApiRepositoryProvider = Provider<GithubApiRepository>((ref) {
   final mock = ref.watch(mockServerProvider);
   if (mock != null) {
     return GithubApiRepositoryImpl(GithubApiClient(mock.dio));

--- a/lib/ui/widget/search_success.dart
+++ b/lib/ui/widget/search_success.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:yumemi_code_check/domain/model/github/github_repository_info.dart';
 import 'package:yumemi_code_check/domain/model/github/search_repository_response.dart';
 import 'package:yumemi_code_check/domain/model/result.dart';
 import 'package:yumemi_code_check/ui/page/repository_detail_page.dart';

--- a/lib/ui/widget/search_success.dart
+++ b/lib/ui/widget/search_success.dart
@@ -8,9 +8,10 @@ class SearchSuccess extends StatelessWidget {
   const SearchSuccess({Key? key, required this.success}) : super(key: key);
   final Success<SearchRepositoryResponse> success;
 
-  List<GithubRepositoryInfo> get items => success.value.items;
   @override
   Widget build(BuildContext context) {
+    final items = success.value.items;
+    
     return Expanded(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16),


### PR DESCRIPTION
## 概要
<!-- なにをやったかを書く -->
コードレビューのフィードバックのリファクタリングを行った
- abstract classで無駄にインターフェース定義している(Dartでは不要)
  - 現在は`abstract class GithubApiRepository`に一つのメソッドしかないが、メソッドが増えた場合を考えるとRepositoryパターンであったほうがいいと思ったため残す
  - もしかしたら、FlutterにはRepositoryを入れ替えるという概念がないのかな...

## 修正箇所
<!-- 修正した場所があれば書く -->

- 保持が必要なGlobalKeyがbuildメソッド内で生成されている
- TextFormFieldに`textInputAction: TextInputAction.search`が指定されていない
- `.vscode/settings.json`に `dart.flutterSdkPath`のfvm指定が無い
- Prividerで無駄に `.autoDispose`が付いてるものがある
  - https://riverpod.dev/docs/concepts/modifiers/auto_dispose/
- https://github.com/Yamasaki-pan961/yumemi_code_check/blob/42f7381100eccce4e893bd140494ad91ffb8192a/lib/ui/widget/search_success.dart#L11 でpublic なgetterがあるのはおかしい(ここの場合、buildメソッド内でのローカル変数が過不足ない)

## UIの比較
<!-- UIの変更があった場合は書く -->
| 変更前 | 変更後 |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/54800851/171543803-2a1dfc65-875b-46bd-af70-ff5a826bff9b.png) | ![image](https://user-images.githubusercontent.com/54800851/171543667-0e8593c0-1fdd-4ad4-948f-b0b571e14dbb.png) |

## issues
<!-- issueのリンクを書く -->
- #24 


## 動作条件
<!-- 動作条件を書く　バージョンなど -->
- Flutter 2.10.5
- Dart 2.16.2
- MinimumOSVersion = 9.0
- compileSdkVersion = 31
- minSdkVersion = 16
- targetSdkVersion = 31
